### PR TITLE
Preserve colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ nvim-tetris is a work-in-progress, and is not feature complete.
 - You can install the plugin just like any other Neovim plugin. I personally use [vim-plug](https://github.com/junegunn/vim-plug).
 - Another way to install would be to just clone this repo into `~/.local/share/nvim/site/pack/*/start/`, where `*` is whatever you choose (I use "alec").
 - After installing, you can launch a game of Tetris using the `:Tetris` command inside Neovim.
+- If your colours look weird, ensure you are using a terminal which supports true colour, you have configured tmux for true colour support if you are using tmux, and you have the `termguicolors` option enabled in Neovim.
 
 ## Controls
 - Left Arrow: move left

--- a/fnl/nvim-tetris/const.fnl
+++ b/fnl/nvim-tetris/const.fnl
@@ -17,16 +17,16 @@
                   "paused" 4
                   "gameover" 5})
 
-(def colours {:TetrisBackground "Black"
-              :TetrisHeader "DarkGray"
-              :TetrisIPiece "Cyan"
-              :TetrisJPiece "Blue"
-              :TetrisLPiece "Orange"
-              :TetrisOPiece "Yellow"
-              :TetrisSPiece "Green"
-              :TetrisTPiece "Purple"
-              :TetrisZPiece "Red"
-              :TetrisShadow "LightGray"})
+(def colours {:TetrisBackground {:guifg "Black" :ctermfg "Black"}
+              :TetrisHeader {:guifg "DarkGray" :ctermfg "DarkGray"}
+              :TetrisIPiece {:guifg "Cyan" :ctermfg "DarkCyan"}
+              :TetrisJPiece {:guifg "Blue" :ctermfg "DarkBlue"}
+              :TetrisLPiece {:guifg "Orange" :ctermfg "Brown"}
+              :TetrisOPiece {:guifg "Yellow" :ctermfg "Yellow"}
+              :TetrisSPiece {:guifg "Green" :ctermfg "DarkGreen"}
+              :TetrisTPiece {:guifg "Purple" :ctermfg "DarkMagenta"}
+              :TetrisZPiece {:guifg "Red" :ctermfg "DarkRed"}
+              :TetrisShadow {:guifg "LightGray" :ctermfg "LightGray"}})
 
 ; following "How Guideline SRS Really Works" from https://harddrop.com/wiki/SRS
 ; How wallkicking works: say we're changing an I piece from rotation state 0 to 1

--- a/fnl/nvim-tetris/io.fnl
+++ b/fnl/nvim-tetris/io.fnl
@@ -75,8 +75,8 @@
 
 ; Sets all the tetris highlights based on the `colours` array in const.fnl
 (defn- init_highlights []
-  (each [group colour (pairs const.colours)]
-    (api.nvim_command (.. "hi " group " guifg=" colour))))
+  (each [group colours (pairs const.colours)]
+    (api.nvim_command (.. "hi " group " guifg=" colours.guifg " ctermfg=" colours.ctermfg))))
 
 ; create the initial buffer and window for drawing the game in
 (defn init_window []

--- a/lua/nvim-tetris/const.lua
+++ b/lua/nvim-tetris/const.lua
@@ -157,7 +157,7 @@ local colours = nil
 do
   local v_0_ = nil
   do
-    local v_0_0 = {TetrisBackground = "Black", TetrisHeader = "DarkGray", TetrisIPiece = "Cyan", TetrisJPiece = "Blue", TetrisLPiece = "Orange", TetrisOPiece = "Yellow", TetrisSPiece = "Green", TetrisShadow = "LightGray", TetrisTPiece = "Purple", TetrisZPiece = "Red"}
+    local v_0_0 = {TetrisBackground = {ctermfg = "Black", guifg = "Black"}, TetrisHeader = {ctermfg = "DarkGray", guifg = "DarkGray"}, TetrisIPiece = {ctermfg = "Cyan", guifg = "Cyan"}, TetrisJPiece = {ctermfg = "Blue", guifg = "Blue"}, TetrisLPiece = {ctermfg = "Brown", guifg = "Orange"}, TetrisOPiece = {ctermfg = "Yellow", guifg = "Yellow"}, TetrisSPiece = {ctermfg = "Green", guifg = "Green"}, TetrisShadow = {ctermfg = "LightGray", guifg = "LightGray"}, TetrisTPiece = {ctermfg = "DarkMagenta", guifg = "Purple"}, TetrisZPiece = {ctermfg = "Red", guifg = "Red"}}
     _0_0["colours"] = v_0_0
     v_0_ = v_0_0
   end

--- a/lua/nvim-tetris/io.lua
+++ b/lua/nvim-tetris/io.lua
@@ -291,8 +291,8 @@ local init_highlights = nil
 do
   local v_0_ = nil
   local function init_highlights0()
-    for group, colour in pairs(const.colours) do
-      api.nvim_command(("hi " .. group .. " guifg=" .. colour))
+    for group, colours in pairs(const.colours) do
+      api.nvim_command(("hi " .. group .. " guifg=" .. colours.guifg .. " ctermfg=" .. colours.ctermfg))
     end
     return nil
   end

--- a/plugin/nvim-tetris.vim
+++ b/plugin/nvim-tetris.vim
@@ -2,7 +2,6 @@ if exists('g:loaded_nvim_tetris') | finish | endif " prevent loading file twice
 
 let s:save_cpo = &cpo " save user coptions
 set cpo&vim " reset them to defaults
-set termguicolors
 
 if has("nvim")
   command Tetris lua require("nvim-tetris.main").init()


### PR DESCRIPTION
Set ctermfg fallback colors for compatibility if the user doesn't have termguicolors set. Also don't set termguicolors, to avoid breaking users' colorschemes.